### PR TITLE
As of Babel 5.8.11 a blank string is considered a moduleRoot

### DIFF
--- a/lib/sprockets/es6.rb
+++ b/lib/sprockets/es6.rb
@@ -29,7 +29,7 @@ module Sprockets
       result = input[:cache].fetch(@cache_key + [data]) do
         opts = @options.merge(
           'sourceRoot' => input[:load_path],
-          'moduleRoot' => '',
+          'moduleRoot' => nil,
           'filename' => input[:filename],
           'filenameRelative' => input[:environment].split_subpath(input[:load_path], input[:filename])
         )


### PR DESCRIPTION
Before 5.8.11, it would output `define("foo",`
As of 5.8.11 it is now (incorrectly) outputting `define("/foo",`
This PR, changes it back to `define("foo",`

I haven't added any tests, because running the existing test suite with the latest version of Babel should fail.

The babel commit in question (https://github.com/babel/babel/commit/27c068874265a1a0ad47c52ad5332c2bf1593d8b)
