### PR TITLE
Process .jsx files

### DIFF
--- a/lib/sprockets/es6.rb
+++ b/lib/sprockets/es6.rb
@@ -47,7 +47,7 @@ module Sprockets
   end
 
   append_path Babel::Transpiler.source_path
-  register_mime_type 'text/ecmascript-6', extensions: ['.es6'], charset: :unicode
+  register_mime_type 'text/ecmascript-6', extensions: ['.es6', '.jsx'], charset: :unicode
   register_transformer 'text/ecmascript-6', 'application/javascript', ES6
   register_preprocessor 'text/ecmascript-6', DirectiveProcessor
 end


### PR DESCRIPTION
This enables sprockets-es6 to transform `.jsx` files.

React's JSTransform is now deprecated in favor of Babel ([facebook.github.io](https://facebook.github.io/react/blog/2015/06/12/deprecating-jstransform-and-react-tools.html)). This means that Babel.js (and consequently, sprockets-es6) will be the new official way to transform JSX files.

Also, `es6` is now an outdated term, it's now called `es2015`; it seems unwise to use `.es6` as a file extension now.
