### PR TITLE
Include filename in cache key

### DIFF
--- a/lib/sprockets/es6.rb
+++ b/lib/sprockets/es6.rb
@@ -26,7 +26,7 @@ module Sprockets
 
     def call(input)
       data = input[:data]
-      result = input[:cache].fetch(@cache_key + [data]) do
+      result = input[:cache].fetch(@cache_key + [input[:filename]] + [data]) do
         opts = {
           'sourceRoot' => input[:load_path],
           'moduleRoot' => nil,

--- a/test/fixtures/mod2.es6
+++ b/test/fixtures/mod2.es6
@@ -1,0 +1,1 @@
+import "foo";

--- a/test/test_es6.rb
+++ b/test/test_es6.rb
@@ -112,6 +112,32 @@ System.register("root/mod", ["foo"], function (_export) {
     JS
   end
 
+  def test_caching_takes_filename_into_account
+    register Sprockets::ES6.new('modules' => 'system', 'moduleIds' => true, 'moduleRoot' => 'root')
+    mod1 = @env["mod.js"]
+    mod2 = @env["mod2.js"]
+    assert_equal <<-JS.chomp, mod1.to_s.strip
+System.register("root/mod", ["foo"], function (_export) {
+  "use strict";
+
+  return {
+    setters: [function (_foo) {}],
+    execute: function () {}
+  };
+});
+    JS
+    assert_equal <<-JS.chomp, mod2.to_s.strip
+System.register("root/mod2", ["foo"], function (_export) {
+  "use strict";
+
+  return {
+    setters: [function (_foo) {}],
+    execute: function () {}
+  };
+});
+    JS
+  end
+
   def register(processor)
     @env.register_transformer 'text/ecmascript-6', 'application/javascript', processor
   end


### PR DESCRIPTION
When an ES6 file is renamed, we need to recompile it, even if the
contents hasn't changed. This is because the module's path has changed,
and depending on the module loader, the compiled output will need to
reflect this.

For example, using SystemJS, if you rename an empty file from app.es6
to app1.es6, the output needs to change from:

``` javascript
System.register("app", [], function (_export) {
  // rest of output
});
```

To:

``` javascript
System.register("app1", [], function (_export) {
  // rest of output
});
```

Otherwise, when you rename the file, the module will still be registered as "app", and `imports` from other files from 'app1' will fail.
