### PR TITLE
Call to register_engine to add ourselves to the extname_map

### DIFF
--- a/lib/sprockets/es6.rb
+++ b/lib/sprockets/es6.rb
@@ -50,4 +50,5 @@ module Sprockets
   register_mime_type 'text/ecmascript-6', extensions: ['.es6'], charset: :unicode
   register_transformer 'text/ecmascript-6', 'application/javascript', ES6
   register_preprocessor 'text/ecmascript-6', DirectiveProcessor
+  register_engine '.es6', ES6
 end

--- a/test/fixtures/file.js.es6
+++ b/test/fixtures/file.js.es6
@@ -1,0 +1,1 @@
+var square = (n) => n * n

--- a/test/fixtures/require_asset.js.erb
+++ b/test/fixtures/require_asset.js.erb
@@ -1,0 +1,1 @@
+<% require_asset "file.js.es6" %>

--- a/test/test_es6.rb
+++ b/test/test_es6.rb
@@ -8,6 +8,18 @@ class TestES6 < MiniTest::Test
     @env.append_path File.expand_path("../fixtures", __FILE__)
   end
 
+  def test_require_asset
+    assert asset = @env["require_asset"]
+    assert_equal 'application/javascript', asset.content_type
+    assert_equal <<-JS.chomp, asset.to_s.strip
+"use strict";
+
+var square = function square(n) {
+  return n * n;
+};
+    JS
+  end
+
   def test_transform_arrow_function
     assert asset = @env["math.js"]
     assert_equal 'application/javascript', asset.content_type


### PR DESCRIPTION
I'm using the `jasmine-rails` and I'm getting this error:

```
couldn't find file 'foo_spec.js.es6' with type 'application/javascript'
```

After much debugging, it turns out es6 isn't even in the ext graph that sprocket generates.  This PR adds es6 and fixes the issue.
