### PR TITLE
Cannot `require` from es6

### DIFF
--- a/lib/sprockets/es6.rb
+++ b/lib/sprockets/es6.rb
@@ -47,8 +47,5 @@ module Sprockets
   end
 
   append_path Babel::Transpiler.source_path
-  register_mime_type 'text/ecmascript-6', extensions: ['.es6'], charset: :unicode
-  register_transformer 'text/ecmascript-6', 'application/javascript', ES6
-  register_preprocessor 'text/ecmascript-6', DirectiveProcessor
-  register_engine '.es6', ES6
+  register_engine '.es6', ES6, mime_type: 'application/javascript'
 end

--- a/test/fixtures/es5_file.js
+++ b/test/fixtures/es5_file.js
@@ -1,0 +1,3 @@
+function square(n) {
+  return n * n;
+};

--- a/test/fixtures/es6_require.es6
+++ b/test/fixtures/es6_require.es6
@@ -1,1 +1,3 @@
-//= require es5_file
+//= require "es5_file.js"
+
+let x = 10;

--- a/test/fixtures/es6_require.es6
+++ b/test/fixtures/es6_require.es6
@@ -1,0 +1,1 @@
+//= require es5_file

--- a/test/test_es6.rb
+++ b/test/test_es6.rb
@@ -22,6 +22,15 @@ var square = function square(n) {
 
   def test_require_asset_from_es6
     assert asset = @env["es6_require"]
+    assert_equal 'application/javascript', asset.content_type
+    assert_equal <<-JS.chomp, asset.to_s.strip
+function square(n) {
+  return n * n;
+};
+"use strict";
+
+var x = 10;
+    JS
   end
 
   def test_transform_arrow_function
@@ -155,6 +164,6 @@ System.register("root/mod2", ["foo"], function (_export) {
   end
 
   def register(processor)
-    @env.register_transformer 'text/ecmascript-6', 'application/javascript', processor
+    @env.register_engine '.es6', processor, mime_type: 'application/javascript'
   end
 end

--- a/test/test_es6.rb
+++ b/test/test_es6.rb
@@ -20,6 +20,10 @@ var square = function square(n) {
     JS
   end
 
+  def test_require_asset_from_es6
+    assert asset = @env["es6_require"]
+  end
+
   def test_transform_arrow_function
     assert asset = @env["math.js"]
     assert_equal 'application/javascript', asset.content_type


### PR DESCRIPTION
Right now this is just a failing test case for using the `require` directive to grab a JS file.
Sprockets throws a `FileNotFound` exception. With the following files:

``` javascript
// some_file.es6
//= require es5_file
```

``` javascript
// es5_file.js

function square(n) {
  return n * n;
};
```

Trying to compile this will result in the following error:

``` ruby
Sprockets::FileNotFound: couldn't find file 'es5_file' with type 'text/ecmascript-6'
```

 I'd like to fix this, but don't quite know what the best way to come at the problem is since it seems to be with passing the ecmascript-6 mime type along to the `resolve!` call in `sprockets/resolve`.
