### PR TITLE
Add configuration block

### DIFF
--- a/lib/sprockets/es6.rb
+++ b/lib/sprockets/es6.rb
@@ -1,19 +1,43 @@
 require 'babel/transpiler'
 require 'sprockets'
 require 'sprockets/es6/version'
+require 'ostruct'
 
 module Sprockets
   class ES6
-    def self.instance
-      @instance ||= new
+
+    class << self
+
+      attr_accessor :configuration
+
+      def configuration_hash
+        configuration.to_h.reduce({}) do |hash, (key, val)|
+          hash[key.to_s] = val
+          hash
+        end
+      end
+
+      def instance
+        @instance ||= new
+      end
+
+      def configure
+        self.configuration = OpenStruct.new
+        yield configuration
+      end
+
+      def call(input)
+        instance.call(input)
+      end
+
     end
 
-    def self.call(input)
-      instance.call(input)
+    def configuration_hash
+      self.class.configuration_hash
     end
 
     def initialize(options = {})
-      @options = options.dup.freeze
+      @options = configuration_hash.merge(options).freeze
 
       @cache_key = [
         self.class.name,

--- a/lib/sprockets/es6.rb
+++ b/lib/sprockets/es6.rb
@@ -51,23 +51,32 @@ module Sprockets
     def call(input)
       data = input[:data]
       result = input[:cache].fetch(@cache_key + [input[:filename]] + [data]) do
-        opts = {
-          'sourceRoot' => input[:load_path],
-          'moduleRoot' => nil,
-          'filename' => input[:filename],
-          'filenameRelative' => input[:environment].split_subpath(input[:load_path], input[:filename])
-        }.merge(@options)
-
-        if opts['moduleIds'] && opts['moduleRoot']
-          opts['moduleId'] ||= File.join(opts['moduleRoot'], input[:name])
-        elsif opts['moduleIds']
-          opts['moduleId'] ||= input[:name]
-        end
-
-        Babel::Transpiler.transform(data, opts)
+        transform(data, transformation_options(input))
       end
       result['code']
     end
+
+    def transform(data, opts)
+      Babel::Transpiler.transform(data, opts)
+    end
+
+    def transformation_options(input)
+      opts = {
+        'sourceRoot' => input[:load_path],
+        'moduleRoot' => nil,
+        'filename' => input[:filename],
+        'filenameRelative' => input[:environment].split_subpath(input[:load_path], input[:filename])
+      }.merge(@options)
+
+      if opts['moduleIds'] && opts['moduleRoot']
+        opts['moduleId'] ||= File.join(opts['moduleRoot'], input[:name])
+      elsif opts['moduleIds']
+        opts['moduleId'] ||= input[:name]
+      end
+
+      opts
+    end
+
   end
 
   append_path Babel::Transpiler.source_path

--- a/lib/sprockets/es6.rb
+++ b/lib/sprockets/es6.rb
@@ -26,6 +26,10 @@ module Sprockets
         yield configuration
       end
 
+      def reset_configuration
+        self.configuration = OpenStruct.new
+      end
+
       def call(input)
         instance.call(input)
       end

--- a/lib/sprockets/es6.rb
+++ b/lib/sprockets/es6.rb
@@ -22,7 +22,7 @@ module Sprockets
       end
 
       def configure
-        self.configuration = OpenStruct.new
+        self.configuration ||= OpenStruct.new
         yield configuration
       end
 

--- a/test/test_es6.rb
+++ b/test/test_es6.rb
@@ -167,6 +167,7 @@ System.register("root/mod2", ["foo"], function (_export) {
     )
     assert_equal transformation_options['modules'], 'amd'
     assert transformation_options['moduleIds']
+    Sprockets::ES6.reset_configuration
   end
 
   def register(processor)

--- a/test/test_es6.rb
+++ b/test/test_es6.rb
@@ -150,6 +150,25 @@ System.register("root/mod2", ["foo"], function (_export) {
     JS
   end
 
+  def test_class_level_transformation_configuration
+    Sprockets::ES6.configure do |config|
+      config.modules = 'amd'
+      config.moduleIds = true
+    end
+    processor = Sprockets::ES6.new
+
+    mock_env = OpenStruct.new
+    def mock_env.split_subpath(*args)
+      nil
+    end
+
+    transformation_options = processor.transformation_options(
+      :environment => mock_env
+    )
+    assert_equal transformation_options['modules'], 'amd'
+    assert transformation_options['moduleIds']
+  end
+
   def register(processor)
     @env.register_transformer 'text/ecmascript-6', 'application/javascript', processor
   end


### PR DESCRIPTION
This is a follow up on https://github.com/TannerRogalsky/sprockets-es6/pull/18 : 

For files with `.js.es6` extension, registering a transformer instance like below does not work: 

```
Rails.application.config.assets.configure do |env|
  es6amd = Sprockets::ES6.new('modules' => 'amd', 'moduleIds' => true)
  env.register_transformer 'text/ecmascript-6', 'application/javascript', es6amd
end
```

As observed in the stack trace below, the registered transformer instance is not invoked when the relevant file is pre-processed: 

```
=> #0  initialize <Sprockets::ES6#initialize(options=?)>
   #1 [method]  initialize <Sprockets::ES6#initialize(options=?)>
   #2 [method]  instance <Sprockets::ES6.instance()>
   #3 [method]  call <Sprockets::ES6.call(input)>
   #4 [method]  call_processor <Sprockets::ProcessorUtils#call_processor(processor, input)>
   #5 [block]   block in call_processors <Sprockets::ProcessorUtils#call_processors(processors, input)>
   #6 [method]  call_processors <Sprockets::ProcessorUtils#call_processors(processors, input)>
   #7 [method]  load_from_unloaded <Sprockets::Loader#load_from_unloaded(unloaded)>
   #8 [block]   block in load <Sprockets::Loader#load(uri)>
   #9 [method]  fetch_asset_from_dependency_cache <Sprockets::Loader#fetch_asset_from_dependency_cache(unloaded, limit=?)>
   #10 [method]  load <Sprockets::Loader#load(uri)>
   #11 [block]   block in initialize <Sprockets::CachedEnvironment#initialize(environment)>
   #12 [method]  load <Sprockets::CachedEnvironment#load(uri)>
   #13 [block]   block in call <Sprockets::Bundle.call(input)>
   #14 [method]  dfs <Sprockets::Utils#dfs(initial)>
   #15 [method]  call <Sprockets::Bundle.call(input)>
   #16 [method]  call_processor <Sprockets::ProcessorUtils#call_processor(processor, input)>
   #17 [block]   block in call_processors <Sprockets::ProcessorUtils#call_processors(processors, input)>
   #18 [method]  call_processors <Sprockets::ProcessorUtils#call_processors(processors, input)>
   #19 [method]  load_from_unloaded <Sprockets::Loader#load_from_unloaded(unloaded)>
   #20 [block]   block in load <Sprockets::Loader#load(uri)>
   #21 [method]  fetch_asset_from_dependency_cache <Sprockets::Loader#fetch_asset_from_dependency_cache(unloaded, limit=?)>
   #22 [method]  load <Sprockets::Loader#load(uri)>
```

I propose that we provide a simple way to configure the options passed to babel through a singleton method which does not require direct instantiation at all: 

```
Sprockets::ES6.configure do |config|
  config.modules = 'amd'
  config.moduleIds = true
end
```
