### PR TITLE
Optional safety wrapper

### DIFF
--- a/lib/sprockets/es6.rb
+++ b/lib/sprockets/es6.rb
@@ -41,6 +41,7 @@ module Sprockets
     end
 
     def initialize(options = {})
+      @safety_wrapper = options.delete('safety_wrapper') || false
       @options = configuration_hash.merge(options).freeze
 
       @cache_key = [
@@ -61,7 +62,11 @@ module Sprockets
     end
 
     def transform(data, opts)
-      Babel::Transpiler.transform(data, opts)
+      result = Babel::Transpiler.transform(data, opts)
+      if @safety_wrapper
+        result['code'] = "(function() {\n#{result['code']}\n}).call(this);\n"
+      end
+      result
     end
 
     def transformation_options(input)

--- a/test/test_es6.rb
+++ b/test/test_es6.rb
@@ -170,6 +170,20 @@ System.register("root/mod2", ["foo"], function (_export) {
     Sprockets::ES6.reset_configuration
   end
 
+  def test_safety_closure
+    register Sprockets::ES6.new('safety_wrapper' => true)
+    assert asset = @env["math.js"]
+    assert_equal <<-JS.chomp, asset.to_s.strip
+(function() {
+"use strict";
+
+var square = function square(n) {
+  return n * n;
+};
+}).call(this);
+    JS
+  end
+
   def register(processor)
     @env.register_transformer 'text/ecmascript-6', 'application/javascript', processor
   end


### PR DESCRIPTION
This PR adds the possibility to use a safety closure for every js file. 

Babel generates some variables that could collapse once the files. In the following example, `_templateObject` is overridden and  `templateFoo` returns the contect of `templateBar`.

Input:

``` js
// ------ application.js
//= require ./tag
//= require ./template_foo
//= require ./template_bar

// ------ tag,es6
const tag = () => {}

// ------ template_foo.es6
const templateFoo = tag`foo`

// ------ template_bar.es6
const templateBar = tag`bar`
```

Output:

``` js
"use strict";

var tag = function tag() {};
"use strict";

var _templateObject = _taggedTemplateLiteral(["foo"], ["foo"]);

function _taggedTemplateLiteral(strings, raw) { return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }

var templateFoo = tag(_templateObject);
"use strict";

var _templateObject = _taggedTemplateLiteral(["bar"], ["bar"]);

function _taggedTemplateLiteral(strings, raw) { return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }

var templateBar = tag(_templateObject);
```

This could easily be avoided by using an IIFE or a safety wrapper to have `_templateObject` defined on a local scope instead of being on `window`. The output is then:

``` js
(function() {
"use strict";

var tag = function tag() {};
}).call(this);
(function() {
"use strict";

var _templateObject = _taggedTemplateLiteral(["foo"], ["foo"]);

function _taggedTemplateLiteral(strings, raw) { return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }

var templateFoo = tag(_templateObject);
}).call(this);
(function() {
"use strict";

var _templateObject = _taggedTemplateLiteral(["bar"], ["bar"]);

function _taggedTemplateLiteral(strings, raw) { return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }

var templateBar = tag(_templateObject);
}).call(this);
```

(free to everyone to explicitly assign variables to the global scope: `window.tags = ...`, `window.templateFoo = ...`, `window.templateBar = ...`).

It is basically what coffeescript is doing by default (unless you pass the `--bare` option) and it would be useful to have it with es6 as well.
