### PR TITLE
Added location and context for require statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ gem 'sprockets-es6'
 
 
 ``` ruby
+# application.rb
+# [...]
+require "action_view/railtie"
+require "sprockets/railtie"
+# require "rails/test_unit/railtie"
 require 'sprockets/es6'
+# [...]
 ```
 
 ``` js


### PR DESCRIPTION
Hey guys thanks for the great addition to sprockets.

As someone who teaches beginners, I've noticed a few people having problems with where to put the require statement from the README. I updated it to provide some extra context.
