### PR TITLE
Drop deprecated method #register_engine

### DIFF
--- a/lib/sprockets/es6.rb
+++ b/lib/sprockets/es6.rb
@@ -87,5 +87,4 @@ module Sprockets
   register_mime_type 'text/ecmascript-6', extensions: ['.es6'], charset: :unicode
   register_transformer 'text/ecmascript-6', 'application/javascript', ES6
   register_preprocessor 'text/ecmascript-6', DirectiveProcessor
-  register_engine '.es6', ES6
 end


### PR DESCRIPTION
Get rid of the deprecation warning. More on https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors.
