### PR TITLE
Fix Sprockets deprecation warning with v3 and v4 support

### DIFF
--- a/lib/sprockets/es6.rb
+++ b/lib/sprockets/es6.rb
@@ -84,8 +84,17 @@ module Sprockets
   end
 
   append_path Babel::Transpiler.source_path
-  register_mime_type 'text/ecmascript-6', extensions: ['.es6'], charset: :unicode
-  register_transformer 'text/ecmascript-6', 'application/javascript', ES6
-  register_preprocessor 'text/ecmascript-6', DirectiveProcessor
-  register_engine '.es6', ES6
+  
+  if respond_to?(:register_transformer)
+    register_mime_type 'text/ecmascript-6', extensions: ['.es6'], charset: :unicode
+    register_transformer 'text/ecmascript-6', 'application/javascript', ES6
+    register_preprocessor 'text/ecmascript-6', DirectiveProcessor
+  end
+  
+  if respond_to?(:register_engine)
+    args = ['.es6', ES6]
+    args << { mime_type: 'text/ecmascript-6', silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
+    register_engine(*args)
+  end
+
 end


### PR DESCRIPTION
No need to use `register_engine` method as we specify all the the others for Sprockets v4 support. But since gem still allows Sprockets 3 we need to support it and use the `register_engine` method. This follows the [Sprockets upgrade guidelines](https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#registering-all-versions-of-sprockets-in-processors) although I'm unaware if other changes are necessary. I'm able to contribute more with some help/advice.
