### PR TITLE
Add cache_key to transformer

### DIFF
--- a/lib/sprockets/es6.rb
+++ b/lib/sprockets/es6.rb
@@ -34,7 +34,13 @@ module Sprockets
         instance.call(input)
       end
 
+      def cache_key
+        instance.cache_key
+      end
+
     end
+
+    attr_reader :cache_key
 
     def configuration_hash
       self.class.configuration_hash

--- a/test/test_es6.rb
+++ b/test/test_es6.rb
@@ -170,6 +170,17 @@ System.register("root/mod2", ["foo"], function (_export) {
     Sprockets::ES6.reset_configuration
   end
 
+  def test_cache_key
+    assert Sprockets::ES6.cache_key
+
+    amd_processor_1 = Sprockets::ES6.new('modules' => 'amd')
+    amd_processor_2 = Sprockets::ES6.new('modules' => 'amd')
+    assert_equal amd_processor_1.cache_key, amd_processor_2.cache_key
+
+    system_processor = Sprockets::ES6.new('modules' => 'system')
+    refute_equal amd_processor_1.cache_key, system_processor.cache_key
+  end
+
   def register(processor)
     @env.register_transformer 'text/ecmascript-6', 'application/javascript', processor
   end


### PR DESCRIPTION
This ensures the cache will be invalidated if the options are changed.
